### PR TITLE
feat: add scale overlay to CAGED visualizer

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Bash(npm run test:*)",
       "Bash(npm run format:*)",
       "Bash(wc:*)",
-      "Bash(npm run test:coverage:*)"
+      "Bash(npm run test:coverage:*)",
+      "Bash(npx vitest:*)",
+      "Bash(gh pr:*)"
     ],
     "deny": [],
     "ask": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -512,7 +511,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -556,7 +554,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1929,7 +1926,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2013,7 +2011,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2024,7 +2021,6 @@
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2075,7 +2071,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2456,7 +2451,6 @@
       "integrity": "sha512-fvDz8o7SQpFLoSBo6Cudv+fE85/fPCkwTnLAN85M+Jv7k59w2mSIjT9Q5px7XwGrmYqqKBEYxh/09IBGd1E7AQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.14",
         "fflate": "^0.8.2",
@@ -2493,7 +2487,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2560,6 +2553,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2687,7 +2681,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -2971,7 +2964,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.208",
@@ -3103,7 +3097,6 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3810,7 +3803,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -4267,6 +4259,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4662,6 +4655,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4677,6 +4671,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4699,7 +4694,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4709,7 +4703,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4722,7 +4715,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5151,7 +5145,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5270,7 +5263,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5349,7 +5341,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
       "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5441,7 +5432,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5455,7 +5445,6 @@
       "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.14",
         "@vitest/mocker": "4.0.14",
@@ -5745,7 +5734,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5775,7 +5763,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/index.css
+++ b/src/index.css
@@ -40,3 +40,17 @@ body {
 .fret-cell {
   height: 2rem;
 }
+
+/* Stacked ring colors for fretboard dots (key note, pentatonic, scale).
+   Used with box-shadow to layer multiple rings on a single dot. */
+.fretboard-rings {
+  --ring-key: #1f2937; /* gray-800 */
+  --ring-pent: #16a34a; /* green-600 */
+  --ring-scale: #7c3aed; /* violet-600 */
+}
+
+.dark .fretboard-rings {
+  --ring-key: #e5e7eb; /* gray-200 */
+  --ring-pent: #22c55e; /* green-500 */
+  --ring-scale: #8b5cf6; /* violet-500 */
+}

--- a/src/shared/components/FretboardDisplay.tsx
+++ b/src/shared/components/FretboardDisplay.tsx
@@ -32,6 +32,10 @@ interface FretboardDisplayProps {
   shouldShowNoteName: (stringIndex: StringIndex, fretNumber: FretNumber) => boolean;
   /** Function to get note name string for specific position */
   getNoteNameAtFret: (stringIndex: StringIndex, fretNumber: FretNumber) => string;
+  /** Whether to show scale overlay dots */
+  showScaleOverlay?: boolean;
+  /** Function to determine if scale dot should be shown at position */
+  shouldShowScaleDot?: (stringIndex: StringIndex, fretNumber: FretNumber) => boolean;
   /** Optional custom aria label for the fretboard */
   ariaLabel?: string;
   /** Optional key note indicator text */
@@ -78,6 +82,8 @@ function FretboardDisplay({
   shouldShowOverlayDot,
   shouldShowNoteName,
   getNoteNameAtFret,
+  showScaleOverlay = false,
+  shouldShowScaleDot,
   ariaLabel,
   keyNoteIndicator = 'R',
 }: FretboardDisplayProps) {
@@ -131,35 +137,72 @@ function FretboardDisplay({
                     aria-hidden="true"
                   />
 
-                  {/* Main pattern dot */}
-                  {shouldShowDot(stringIndex as StringIndex, fretIndex + 1) && (
-                    <div
-                      className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center text-white text-xs font-medium shadow-sm ${
-                        isKeyNote(stringIndex as StringIndex, fretIndex + 1)
-                          ? 'ring-2 ring-gray-800 dark:ring-gray-200'
-                          : ''
-                      } ${
-                        showOverlay &&
-                        shouldShowOverlayDot(stringIndex as StringIndex, fretIndex + 1)
-                          ? 'ring-2 ring-green-600 dark:ring-green-500'
-                          : ''
-                      }`}
-                      style={getDotStyle(stringIndex as StringIndex, fretIndex + 1)}
-                      aria-label={`${isKeyNote(stringIndex as StringIndex, fretIndex + 1) ? 'Key note' : 'Pattern note'}${showOverlay && shouldShowOverlayDot(stringIndex as StringIndex, fretIndex + 1) ? ' (also overlay note)' : ''} on ${stringName} string, fret ${fretIndex + 1}`}
-                    >
-                      {isKeyNote(stringIndex as StringIndex, fretIndex + 1) ? keyNoteIndicator : ''}
-                    </div>
-                  )}
+                  {(() => {
+                    const si = stringIndex as StringIndex;
+                    const fi = (fretIndex + 1) as FretNumber;
+                    const hasMain = shouldShowDot(si, fi);
+                    const isKey = isKeyNote(si, fi);
+                    const isPent = showOverlay && shouldShowOverlayDot(si, fi);
+                    const isScale = showScaleOverlay && !!shouldShowScaleDot?.(si, fi);
 
-                  {/* Overlay dot (when not covered by main dot) */}
-                  {showOverlay &&
-                    shouldShowOverlayDot(stringIndex as StringIndex, fretIndex + 1) &&
-                    !shouldShowDot(stringIndex as StringIndex, fretIndex + 1) && (
+                    // Build stacked rings via box-shadow (each ring +2px wider than previous).
+                    // Order: innermost = key note, then pentatonic, then scale.
+                    const buildRings = (startOffset: number) => {
+                      const shadows: string[] = [];
+                      let offset = startOffset;
+                      if (isKey) {
+                        shadows.push(`0 0 0 2px var(--ring-key)`);
+                        offset += 2;
+                      }
+                      if (isPent) {
+                        shadows.push(`0 0 0 ${offset + 2}px var(--ring-pent)`);
+                        offset += 2;
+                      }
+                      if (isScale) {
+                        shadows.push(`0 0 0 ${offset + 2}px var(--ring-scale)`);
+                        offset += 2;
+                      }
+                      return shadows.join(', ');
+                    };
+
+                    if (hasMain) {
+                      const baseStyle = getDotStyle(si, fi) || {};
+                      const ringShadow = buildRings(0);
+                      return (
+                        <div
+                          className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center text-white text-xs font-medium shadow-sm fretboard-rings"
+                          style={ringShadow ? { ...baseStyle, boxShadow: ringShadow } : baseStyle}
+                          aria-label={`${isKey ? 'Key note' : 'Pattern note'}${isPent ? ' (also overlay note)' : ''}${isScale ? ' (also scale note)' : ''} on ${stringName} string, fret ${fretIndex + 1}`}
+                        >
+                          {isKey ? keyNoteIndicator : ''}
+                        </div>
+                      );
+                    }
+
+                    // No main dot — render standalone overlay dot if pentatonic and/or scale present
+                    if (!isPent && !isScale) return null;
+
+                    // Standalone dot: pentatonic takes precedence as the visible body color.
+                    // If scale is also present, add a violet ring around it.
+                    if (isPent) {
+                      const ringShadow = isScale ? `0 0 0 2px var(--ring-scale)` : undefined;
+                      return (
+                        <div
+                          className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-4 h-4 rounded-full border-2 border-green-600 dark:border-green-500 bg-green-600/30 dark:bg-green-500/30 fretboard-rings"
+                          style={ringShadow ? { boxShadow: ringShadow } : undefined}
+                          aria-label={`Overlay note${isScale ? ' (also scale note)' : ''} on ${stringName} string, fret ${fretIndex + 1}`}
+                        />
+                      );
+                    }
+
+                    // Scale only
+                    return (
                       <div
-                        className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-4 h-4 rounded-full border-2 border-green-600 dark:border-green-500 bg-green-600/30 dark:bg-green-500/30"
-                        aria-label={`Overlay note on ${stringName} string, fret ${fretIndex + 1}`}
+                        className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-4 h-4 rounded-full border-2 border-violet-600 dark:border-violet-500 bg-violet-500/30 dark:bg-violet-500/30"
+                        aria-label={`Scale note on ${stringName} string, fret ${fretIndex + 1}`}
                       />
-                    )}
+                    );
+                  })()}
 
                   {/* Note name overlay */}
                   {showNoteNames &&

--- a/src/shared/utils/musicTheory.test.ts
+++ b/src/shared/utils/musicTheory.test.ts
@@ -4,6 +4,8 @@ import {
   getNoteNameAtFret,
   shouldShowNoteName,
   isPentatonicNote,
+  isScaleNote,
+  getScalePositions,
   calculateChromaticDistance,
   transposePattern,
   CHROMATIC_TO_NOTE_NAME,
@@ -156,6 +158,102 @@ describe('musicTheory utilities', () => {
     it('should start with C and end with B', () => {
       expect(CHROMATIC_TO_NOTE_NAME[0]).toBe('C');
       expect(CHROMATIC_TO_NOTE_NAME[11]).toBe('B');
+    });
+  });
+
+  describe('isScaleNote', () => {
+    it('should identify C major scale notes correctly', () => {
+      const rootNote = 0; // C
+      const majorIntervals = [0, 2, 4, 5, 7, 9, 11];
+
+      // C major scale: C(0), D(2), E(4), F(5), G(7), A(9), B(11)
+      // High E string (tuning=4), fret 8 = C (4+8=12%12=0) -> should be in scale
+      expect(isScaleNote(0, 8, rootNote, majorIntervals)).toBe(true);
+      // High E string, fret 1 = F (4+1=5) -> should be in scale
+      expect(isScaleNote(0, 1, rootNote, majorIntervals)).toBe(true);
+      // High E string, fret 2 = F# (4+2=6) -> NOT in C major
+      expect(isScaleNote(0, 2, rootNote, majorIntervals)).toBe(false);
+    });
+
+    it('should identify Natural Minor scale notes correctly', () => {
+      const rootNote = 9; // A
+      const naturalMinorIntervals = [0, 2, 3, 5, 7, 8, 10];
+
+      // A natural minor: A(9), B(11), C(0), D(2), E(4), F(5), G(7)
+      // A string (tuning=9), fret 0 = A -> in scale
+      expect(isScaleNote(4, 0, rootNote, naturalMinorIntervals)).toBe(true);
+      // A string, fret 2 = B (9+2=11) -> in scale
+      expect(isScaleNote(4, 2, rootNote, naturalMinorIntervals)).toBe(true);
+      // A string, fret 1 = A# (9+1=10) -> NOT in A natural minor
+      expect(isScaleNote(4, 1, rootNote, naturalMinorIntervals)).toBe(false);
+    });
+
+    it('should work for all 9 scale types with different roots', () => {
+      // G Dorian: G(7), A(9), Bb(10), C(0), D(2), E(4), F(5)
+      const rootNote = 7; // G
+      const dorianIntervals = [0, 2, 3, 5, 7, 9, 10];
+
+      // G string (tuning=7), fret 0 = G -> in scale
+      expect(isScaleNote(2, 0, rootNote, dorianIntervals)).toBe(true);
+      // G string, fret 1 = G# (7+1=8) -> NOT in G Dorian
+      expect(isScaleNote(2, 1, rootNote, dorianIntervals)).toBe(false);
+      // G string, fret 2 = A (7+2=9) -> in scale
+      expect(isScaleNote(2, 2, rootNote, dorianIntervals)).toBe(true);
+    });
+
+    it('should handle edge cases at fret 0 and fret 15', () => {
+      const rootNote = 4; // E
+      const majorIntervals = [0, 2, 4, 5, 7, 9, 11];
+
+      // High E string open = E -> in E major
+      expect(isScaleNote(0, 0, rootNote, majorIntervals)).toBe(true);
+      // High E string fret 15 = (4+15)%12 = 7 = G -> check: E major has G#(8), not G(7)
+      expect(isScaleNote(0, 15, rootNote, majorIntervals)).toBe(false);
+    });
+  });
+
+  describe('getScalePositions', () => {
+    it('should return positions across all strings and frets', () => {
+      const rootNote = 0; // C
+      const majorIntervals = [0, 2, 4, 5, 7, 9, 11];
+
+      const positions = getScalePositions(rootNote, majorIntervals);
+
+      // Should have positions across all 6 strings
+      const strings = new Set(positions.map((p) => p.stringIndex));
+      expect(strings.size).toBe(6);
+
+      // Each position should be valid
+      for (const pos of positions) {
+        expect(pos.stringIndex).toBeGreaterThanOrEqual(0);
+        expect(pos.stringIndex).toBeLessThanOrEqual(5);
+        expect(pos.fretNumber).toBeGreaterThanOrEqual(0);
+        expect(pos.fretNumber).toBeLessThanOrEqual(15);
+      }
+    });
+
+    it('should return correct number of positions for a 7-note scale', () => {
+      const rootNote = 0;
+      const majorIntervals = [0, 2, 4, 5, 7, 9, 11];
+
+      const positions = getScalePositions(rootNote, majorIntervals);
+
+      // 7 notes per octave, ~16 frets per string, 6 strings
+      // Each string covers slightly more than 1 octave (16 semitones)
+      // So approximately 7-9 scale notes per string, ~42-54 total
+      expect(positions.length).toBeGreaterThan(40);
+      expect(positions.length).toBeLessThan(60);
+    });
+
+    it('should only contain actual scale notes', () => {
+      const rootNote = 0;
+      const majorIntervals = [0, 2, 4, 5, 7, 9, 11];
+
+      const positions = getScalePositions(rootNote, majorIntervals);
+
+      for (const pos of positions) {
+        expect(isScaleNote(pos.stringIndex, pos.fretNumber, rootNote, majorIntervals)).toBe(true);
+      }
     });
   });
 

--- a/src/shared/utils/musicTheory.ts
+++ b/src/shared/utils/musicTheory.ts
@@ -129,6 +129,50 @@ export function getPentatonicPositions(
 }
 
 /**
+ * Calculate if a note at a specific position is part of a scale
+ * @param stringIndex - Guitar string index
+ * @param fretNumber - Fret number
+ * @param rootNote - Root note chromatic value (0-11)
+ * @param intervals - Scale intervals array (e.g., [0, 2, 4, 5, 7, 9, 11] for major)
+ * @returns True if the note is part of the scale
+ */
+export function isScaleNote(
+  stringIndex: number,
+  fretNumber: number,
+  rootNote: number,
+  intervals: readonly number[]
+): boolean {
+  const noteAtFret = getNoteAtFret(stringIndex, fretNumber);
+  const scaleNotes = intervals.map(
+    (interval) => (rootNote + interval) % FRETBOARD_CONSTANTS.CHROMATIC_OCTAVE
+  );
+  return scaleNotes.includes(noteAtFret);
+}
+
+/**
+ * Get all scale note positions across the fretboard
+ * @param rootNote - Root note chromatic value (0-11)
+ * @param intervals - Scale intervals array
+ * @returns Array of positions containing scale notes
+ */
+export function getScalePositions(
+  rootNote: number,
+  intervals: readonly number[]
+): Array<{ stringIndex: number; fretNumber: number }> {
+  const positions: Array<{ stringIndex: number; fretNumber: number }> = [];
+
+  for (let stringIndex = 0; stringIndex < STANDARD_TUNING.length; stringIndex++) {
+    for (let fretNumber = 0; fretNumber <= FRETBOARD_CONSTANTS.MAX_FRET; fretNumber++) {
+      if (isScaleNote(stringIndex, fretNumber, rootNote, intervals)) {
+        positions.push({ stringIndex, fretNumber });
+      }
+    }
+  }
+
+  return positions;
+}
+
+/**
  * Calculate chromatic distance between two notes
  * @param fromNote - Starting note chromatic value (0-11)
  * @param toNote - Target note chromatic value (0-11)

--- a/src/systems/caged/components/CAGEDVisualizer.tsx
+++ b/src/systems/caged/components/CAGEDVisualizer.tsx
@@ -53,6 +53,8 @@ export default function CAGEDVisualizer() {
     showAllShapes,
     showPentatonic,
     showAllNotes,
+    showScale,
+    selectedScale,
   } = state;
 
   // Use custom hooks for music theory logic and calculations
@@ -63,9 +65,10 @@ export default function CAGEDVisualizer() {
     getShapesAtPosition,
     createGradientStyle,
     isPentatonicNote,
+    isScaleNote,
     getNoteNameAtFret,
     shouldShowNoteName,
-  } = useCAGEDLogic(selectedChord, chordQuality, cagedSequence);
+  } = useCAGEDLogic(selectedChord, chordQuality, cagedSequence, selectedScale);
   const currentShape = cagedSequence[currentPosition];
 
   // Check if a dot should be shown at this position
@@ -146,6 +149,40 @@ export default function CAGEDVisualizer() {
     [isPentatonicNote, showAllShapes, shapePositions, currentShape, chordQuality]
   );
 
+  // Check if a scale dot should be shown at this position
+  const shouldShowScaleDot = useCallback(
+    (stringIndex: number, fretNumber: number) => {
+      if (!isScaleNote(stringIndex, fretNumber)) {
+        return false;
+      }
+
+      // If showing all shapes, show all scale notes across entire fretboard
+      if (showAllShapes) {
+        return true;
+      }
+
+      // When showing single shape, scope to shape's fret range ±2 frets
+      const basePosition = shapePositions[currentShape];
+      const shape = CAGED_SHAPES_BY_QUALITY[chordQuality][currentShape];
+      const shapeFrets = shape.pattern
+        .map((fret: number) => {
+          if (fret === -1) return -1;
+          if (fret === 0 && basePosition === 0) return 0;
+          if (fret === 0 && basePosition > 0) return basePosition;
+          return fret + basePosition;
+        })
+        .filter((f: number) => f >= 0);
+
+      if (shapeFrets.length === 0) return false;
+
+      const minFret = Math.max(0, Math.min(...shapeFrets) - 2);
+      const maxFret = Math.max(...shapeFrets) + 2;
+
+      return fretNumber >= minFret && fretNumber <= maxFret;
+    },
+    [isScaleNote, showAllShapes, shapePositions, currentShape, chordQuality]
+  );
+
   const nextPosition = useCallback(() => {
     actions.nextPosition(cagedSequence.length);
   }, [actions, cagedSequence.length]);
@@ -164,6 +201,7 @@ export default function CAGEDVisualizer() {
     onToggleShowAllShapes: actions.toggleShowAllShapes,
     onToggleShowPentatonic: actions.toggleShowPentatonic,
     onToggleShowAllNotes: actions.toggleShowAllNotes,
+    onToggleShowScale: actions.toggleShowScale,
   });
 
   return (
@@ -193,6 +231,8 @@ export default function CAGEDVisualizer() {
         shouldShowOverlayDot={shouldShowPentatonicDot}
         shouldShowNoteName={shouldShowNoteName}
         getNoteNameAtFret={getNoteNameAtFret}
+        showScaleOverlay={showScale}
+        shouldShowScaleDot={shouldShowScaleDot}
         ariaLabel={`Guitar fretboard showing ${selectedChord} ${chordQuality} chord${showAllShapes ? ' in all CAGED positions' : ''}`}
         keyNoteIndicator="R"
       />
@@ -203,9 +243,13 @@ export default function CAGEDVisualizer() {
         showAllShapes={showAllShapes}
         showPentatonic={showPentatonic}
         showAllNotes={showAllNotes}
+        showScale={showScale}
+        selectedScale={selectedScale}
         onToggleShowAllShapes={actions.toggleShowAllShapes}
         onToggleShowPentatonic={actions.toggleShowPentatonic}
         onToggleShowAllNotes={actions.toggleShowAllNotes}
+        onToggleShowScale={actions.toggleShowScale}
+        onSetScaleType={actions.setScaleType}
       />
     </div>
   );

--- a/src/systems/caged/components/ViewModeToggles.tsx
+++ b/src/systems/caged/components/ViewModeToggles.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import type { ChordType, ChordQuality } from '../types';
+import type { ChordType, ChordQuality, ScaleType } from '../types';
+import { SCALE_DEFINITIONS } from '../constants/scales';
 
 interface ViewModeTogglesProps {
   selectedChord: ChordType;
@@ -7,9 +8,13 @@ interface ViewModeTogglesProps {
   showAllShapes: boolean;
   showPentatonic: boolean;
   showAllNotes: boolean;
+  showScale: boolean;
+  selectedScale: ScaleType;
   onToggleShowAllShapes: () => void;
   onToggleShowPentatonic: () => void;
   onToggleShowAllNotes: () => void;
+  onToggleShowScale: () => void;
+  onSetScaleType: (scaleType: ScaleType) => void;
 }
 
 function ViewModeToggles({
@@ -18,9 +23,13 @@ function ViewModeToggles({
   showAllShapes,
   showPentatonic,
   showAllNotes,
+  showScale,
+  selectedScale,
   onToggleShowAllShapes,
   onToggleShowPentatonic,
   onToggleShowAllNotes,
+  onToggleShowScale,
+  onSetScaleType,
 }: ViewModeTogglesProps) {
   return (
     <div className="mt-6">
@@ -96,6 +105,64 @@ function ViewModeToggles({
               {showAllNotes ? 'ON' : 'OFF'}
             </span>
           </div>
+
+          {/* Scale Overlay Toggle */}
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-700 dark:text-gray-300">Scale</span>
+            <button
+              onClick={onToggleShowScale}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+                showScale ? 'bg-violet-600 dark:bg-violet-500' : 'bg-gray-200 dark:bg-gray-600'
+              }`}
+              aria-pressed={showScale}
+              aria-label={
+                showScale ? 'Hide scale overlay on fretboard' : 'Show scale overlay on fretboard'
+              }
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${
+                  showScale ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+            {showScale && (
+              <select
+                value={selectedScale}
+                onChange={(e) => onSetScaleType(e.target.value as ScaleType)}
+                className="text-xs bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                aria-label="Select scale type"
+              >
+                <optgroup label="Major">
+                  {Object.entries(SCALE_DEFINITIONS)
+                    .filter(([, def]) => def.category === 'major')
+                    .map(([key, def]) => (
+                      <option key={key} value={key}>
+                        {def.name}
+                      </option>
+                    ))}
+                </optgroup>
+                <optgroup label="Minor">
+                  {Object.entries(SCALE_DEFINITIONS)
+                    .filter(([, def]) => def.category === 'minor')
+                    .map(([key, def]) => (
+                      <option key={key} value={key}>
+                        {def.name}
+                      </option>
+                    ))}
+                </optgroup>
+                <optgroup label="Modes">
+                  {Object.entries(SCALE_DEFINITIONS)
+                    .filter(([, def]) => def.category === 'mode')
+                    .map(([key, def]) => (
+                      <option key={key} value={key}>
+                        {def.name}
+                      </option>
+                    ))}
+                </optgroup>
+              </select>
+            )}
+            {!showScale && <span className="text-xs text-gray-500 dark:text-gray-400">OFF</span>}
+          </div>
         </div>
       </section>
 
@@ -139,6 +206,17 @@ function ViewModeToggles({
             </p>
             <p className="text-xs">
               Letter labels: natural notes (E,F,G,A,B,C,D) on all fret positions
+            </p>
+          </div>
+        )}
+
+        {showScale && (
+          <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600">
+            <p className="font-medium text-violet-600 dark:text-violet-400 text-sm">
+              {selectedChord} {SCALE_DEFINITIONS[selectedScale].name} Scale Active
+            </p>
+            <p className="text-xs">
+              Purple dots: scale notes • Split colors: chord + scale overlap
             </p>
           </div>
         )}

--- a/src/systems/caged/constants/scales.test.ts
+++ b/src/systems/caged/constants/scales.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { SCALE_DEFINITIONS } from './scales';
+import type { ScaleType } from './scales';
+
+describe('SCALE_DEFINITIONS', () => {
+  it('should define all 9 scale types', () => {
+    const expectedTypes: ScaleType[] = [
+      'major',
+      'naturalMinor',
+      'harmonicMinor',
+      'melodicMinor',
+      'dorian',
+      'phrygian',
+      'lydian',
+      'mixolydian',
+      'locrian',
+    ];
+    expect(Object.keys(SCALE_DEFINITIONS)).toEqual(expect.arrayContaining(expectedTypes));
+    expect(Object.keys(SCALE_DEFINITIONS)).toHaveLength(9);
+  });
+
+  it('should have 7 intervals per scale (heptatonic)', () => {
+    for (const [key, def] of Object.entries(SCALE_DEFINITIONS)) {
+      expect(def.intervals).toHaveLength(7);
+      expect(def.intervals[0]).toBe(0); // All scales start on root
+      // All intervals must be 0-11
+      for (const interval of def.intervals) {
+        expect(interval).toBeGreaterThanOrEqual(0);
+        expect(interval).toBeLessThanOrEqual(11);
+      }
+      // Intervals must be strictly ascending
+      for (let i = 1; i < def.intervals.length; i++) {
+        expect(def.intervals[i]).toBeGreaterThan(def.intervals[i - 1]);
+      }
+      // Each scale must have a name and category
+      expect(def.name).toBeTruthy();
+      expect(['major', 'minor', 'mode']).toContain(def.category);
+      // Suppress unused variable warning
+      void key;
+    }
+  });
+
+  it('should have musically correct Major scale intervals (W-W-H-W-W-W-H)', () => {
+    expect([...SCALE_DEFINITIONS.major.intervals]).toEqual([0, 2, 4, 5, 7, 9, 11]);
+  });
+
+  it('should have musically correct Natural Minor intervals (W-H-W-W-H-W-W)', () => {
+    expect([...SCALE_DEFINITIONS.naturalMinor.intervals]).toEqual([0, 2, 3, 5, 7, 8, 10]);
+  });
+
+  it('should have musically correct Harmonic Minor intervals (raised 7th)', () => {
+    expect([...SCALE_DEFINITIONS.harmonicMinor.intervals]).toEqual([0, 2, 3, 5, 7, 8, 11]);
+  });
+
+  it('should have musically correct Melodic Minor intervals (raised 6th & 7th)', () => {
+    expect([...SCALE_DEFINITIONS.melodicMinor.intervals]).toEqual([0, 2, 3, 5, 7, 9, 11]);
+  });
+
+  it('should have musically correct Dorian intervals (minor with raised 6th)', () => {
+    expect([...SCALE_DEFINITIONS.dorian.intervals]).toEqual([0, 2, 3, 5, 7, 9, 10]);
+  });
+
+  it('should have musically correct Phrygian intervals (minor with flat 2nd)', () => {
+    expect([...SCALE_DEFINITIONS.phrygian.intervals]).toEqual([0, 1, 3, 5, 7, 8, 10]);
+  });
+
+  it('should have musically correct Lydian intervals (major with raised 4th)', () => {
+    expect([...SCALE_DEFINITIONS.lydian.intervals]).toEqual([0, 2, 4, 6, 7, 9, 11]);
+  });
+
+  it('should have musically correct Mixolydian intervals (major with flat 7th)', () => {
+    expect([...SCALE_DEFINITIONS.mixolydian.intervals]).toEqual([0, 2, 4, 5, 7, 9, 10]);
+  });
+
+  it('should have musically correct Locrian intervals (minor with flat 2nd & 5th)', () => {
+    expect([...SCALE_DEFINITIONS.locrian.intervals]).toEqual([0, 1, 3, 5, 6, 8, 10]);
+  });
+
+  it('should group scales into correct categories', () => {
+    expect(SCALE_DEFINITIONS.major.category).toBe('major');
+
+    expect(SCALE_DEFINITIONS.naturalMinor.category).toBe('minor');
+    expect(SCALE_DEFINITIONS.harmonicMinor.category).toBe('minor');
+    expect(SCALE_DEFINITIONS.melodicMinor.category).toBe('minor');
+
+    expect(SCALE_DEFINITIONS.dorian.category).toBe('mode');
+    expect(SCALE_DEFINITIONS.phrygian.category).toBe('mode');
+    expect(SCALE_DEFINITIONS.lydian.category).toBe('mode');
+    expect(SCALE_DEFINITIONS.mixolydian.category).toBe('mode');
+    expect(SCALE_DEFINITIONS.locrian.category).toBe('mode');
+  });
+});

--- a/src/systems/caged/constants/scales.ts
+++ b/src/systems/caged/constants/scales.ts
@@ -1,0 +1,55 @@
+/**
+ * Scale definitions for the CAGED system scale overlay
+ *
+ * Provides interval patterns for major, minor, and modal scales
+ * used to overlay scale notes on the fretboard alongside CAGED chord shapes.
+ */
+
+/**
+ * Scale type identifier - 9 supported scale types
+ */
+export type ScaleType =
+  | 'major'
+  | 'naturalMinor'
+  | 'harmonicMinor'
+  | 'melodicMinor'
+  | 'dorian'
+  | 'phrygian'
+  | 'lydian'
+  | 'mixolydian'
+  | 'locrian';
+
+/**
+ * Scale definition with display name, intervals, and category grouping
+ */
+export interface ScaleDefinition {
+  /** Display name for the scale */
+  name: string;
+  /** Chromatic intervals from root (semitones) */
+  intervals: readonly number[];
+  /** Category for grouped dropdown display */
+  category: 'major' | 'minor' | 'mode';
+}
+
+/**
+ * All supported scale definitions keyed by ScaleType
+ *
+ * Intervals are expressed as semitones from the root note:
+ * - Major (Ionian): W-W-H-W-W-W-H = [0, 2, 4, 5, 7, 9, 11]
+ * - Natural Minor (Aeolian): W-H-W-W-H-W-W = [0, 2, 3, 5, 7, 8, 10]
+ * - Modes are rotations of the major scale
+ */
+export const SCALE_DEFINITIONS: Record<ScaleType, ScaleDefinition> = {
+  major: { name: 'Major (Ionian)', intervals: [0, 2, 4, 5, 7, 9, 11], category: 'major' },
+  naturalMinor: { name: 'Natural Minor', intervals: [0, 2, 3, 5, 7, 8, 10], category: 'minor' },
+  harmonicMinor: { name: 'Harmonic Minor', intervals: [0, 2, 3, 5, 7, 8, 11], category: 'minor' },
+  melodicMinor: { name: 'Melodic Minor', intervals: [0, 2, 3, 5, 7, 9, 11], category: 'minor' },
+  dorian: { name: 'Dorian', intervals: [0, 2, 3, 5, 7, 9, 10], category: 'mode' },
+  phrygian: { name: 'Phrygian', intervals: [0, 1, 3, 5, 7, 8, 10], category: 'mode' },
+  lydian: { name: 'Lydian', intervals: [0, 2, 4, 6, 7, 9, 11], category: 'mode' },
+  mixolydian: { name: 'Mixolydian', intervals: [0, 2, 4, 5, 7, 9, 10], category: 'mode' },
+  locrian: { name: 'Locrian', intervals: [0, 1, 3, 5, 6, 8, 10], category: 'mode' },
+};
+
+/** Scale overlay dot color */
+export const SCALE_DOT_COLOR = '#8B5CF6';

--- a/src/systems/caged/constants/scales.ts
+++ b/src/systems/caged/constants/scales.ts
@@ -50,6 +50,3 @@ export const SCALE_DEFINITIONS: Record<ScaleType, ScaleDefinition> = {
   mixolydian: { name: 'Mixolydian', intervals: [0, 2, 4, 5, 7, 9, 10], category: 'mode' },
   locrian: { name: 'Locrian', intervals: [0, 1, 3, 5, 6, 8, 10], category: 'mode' },
 };
-
-/** Scale overlay dot color */
-export const SCALE_DOT_COLOR = '#8B5CF6';

--- a/src/systems/caged/hooks/__tests__/useCAGEDLogic.test.ts
+++ b/src/systems/caged/hooks/__tests__/useCAGEDLogic.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { useCAGEDLogic } from '../useCAGEDLogic';
 import type { ChordType, ChordQuality } from '@/shared/types/core';
+import type { ScaleType } from '../../constants/scales';
 
 describe('useCAGEDLogic', () => {
   describe('shape positions', () => {
@@ -308,6 +309,70 @@ describe('useCAGEDLogic', () => {
         expect(pos.fretNumber).toBeGreaterThanOrEqual(0);
         expect(pos.fretNumber).toBeLessThanOrEqual(15);
       });
+    });
+  });
+
+  describe('scale notes', () => {
+    it('should provide isScaleNote function', () => {
+      const { result } = renderHook(() => useCAGEDLogic('C', 'major', ['C'], 'major'));
+      expect(typeof result.current.isScaleNote).toBe('function');
+    });
+
+    it('should identify C major scale notes correctly', () => {
+      const { result } = renderHook(() => useCAGEDLogic('C', 'major', ['C'], 'major'));
+
+      // C is in C major scale: high E string fret 8 = C (4+8=12%12=0)
+      expect(result.current.isScaleNote(0, 8)).toBe(true);
+      // F# is NOT in C major: high E string fret 2 = F# (4+2=6)
+      expect(result.current.isScaleNote(0, 2)).toBe(false);
+    });
+
+    it('should identify Dorian scale notes correctly', () => {
+      const { result } = renderHook(() => useCAGEDLogic('C', 'major', ['C'], 'dorian'));
+
+      // C Dorian: C(0) D(2) Eb(3) F(5) G(7) A(9) Bb(10)
+      // High E string fret 8 = C -> in scale
+      expect(result.current.isScaleNote(0, 8)).toBe(true);
+      // High E string fret 9 = C# (1) -> NOT in C Dorian
+      expect(result.current.isScaleNote(0, 9)).toBe(false);
+    });
+
+    it('should return scale positions array', () => {
+      const { result } = renderHook(() => useCAGEDLogic('C', 'major', ['C'], 'major'));
+
+      const positions = result.current.getScalePositions;
+      expect(Array.isArray(positions)).toBe(true);
+      expect(positions.length).toBeGreaterThan(40);
+
+      positions.forEach((pos) => {
+        expect(pos.stringIndex).toBeGreaterThanOrEqual(0);
+        expect(pos.stringIndex).toBeLessThan(6);
+        expect(pos.fretNumber).toBeGreaterThanOrEqual(0);
+        expect(pos.fretNumber).toBeLessThanOrEqual(15);
+      });
+    });
+
+    it('should update scale notes when scale type changes', () => {
+      const { result, rerender } = renderHook(
+        ({ chord, quality, sequence, scale }) => useCAGEDLogic(chord, quality, sequence, scale),
+        {
+          initialProps: {
+            chord: 'C' as ChordType,
+            quality: 'major' as ChordQuality,
+            sequence: ['C'],
+            scale: 'major' as ScaleType,
+          },
+        }
+      );
+
+      const majorPositions = result.current.getScalePositions;
+
+      rerender({ chord: 'C', quality: 'major', sequence: ['C'], scale: 'dorian' as ScaleType });
+
+      const dorianPositions = result.current.getScalePositions;
+
+      // Major and Dorian have different notes
+      expect(majorPositions).not.toEqual(dorianPositions);
     });
   });
 

--- a/src/systems/caged/hooks/__tests__/useCAGEDState.test.ts
+++ b/src/systems/caged/hooks/__tests__/useCAGEDState.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCAGEDState } from '../useCAGEDState';
+
+describe('useCAGEDState - scale overlay', () => {
+  it('should initialize with showScale=false and selectedScale="major"', () => {
+    const { result } = renderHook(() => useCAGEDState());
+    expect(result.current.state.showScale).toBe(false);
+    expect(result.current.state.selectedScale).toBe('major');
+  });
+
+  it('should toggle showScale ON and OFF', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    act(() => result.current.actions.toggleShowScale());
+    expect(result.current.state.showScale).toBe(true);
+
+    act(() => result.current.actions.toggleShowScale());
+    expect(result.current.state.showScale).toBe(false);
+  });
+
+  it('should set scale type', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    act(() => result.current.actions.setScaleType('dorian'));
+    expect(result.current.state.selectedScale).toBe('dorian');
+
+    act(() => result.current.actions.setScaleType('harmonicMinor'));
+    expect(result.current.state.selectedScale).toBe('harmonicMinor');
+  });
+
+  it('should persist showScale when switching chords', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    act(() => result.current.actions.toggleShowScale());
+    expect(result.current.state.showScale).toBe(true);
+
+    act(() => result.current.actions.setChord('G'));
+    expect(result.current.state.showScale).toBe(true);
+    expect(result.current.state.selectedScale).toBe('major');
+  });
+
+  it('should persist showScale when switching chord quality', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    act(() => result.current.actions.toggleShowScale());
+    act(() => result.current.actions.setScaleType('dorian'));
+
+    act(() => result.current.actions.setChordQuality('minor'));
+    expect(result.current.state.showScale).toBe(true);
+    // Dorian should NOT auto-switch (only major↔naturalMinor)
+    expect(result.current.state.selectedScale).toBe('dorian');
+  });
+
+  it('should auto-switch Major→Natural Minor on quality change to minor', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    // Default scale is 'major'
+    expect(result.current.state.selectedScale).toBe('major');
+
+    act(() => result.current.actions.setChordQuality('minor'));
+    expect(result.current.state.selectedScale).toBe('naturalMinor');
+  });
+
+  it('should auto-switch Natural Minor→Major on quality change to major', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    // Set to natural minor first
+    act(() => result.current.actions.setScaleType('naturalMinor'));
+    act(() => result.current.actions.setChordQuality('minor'));
+    expect(result.current.state.selectedScale).toBe('naturalMinor');
+
+    act(() => result.current.actions.setChordQuality('major'));
+    expect(result.current.state.selectedScale).toBe('major');
+  });
+
+  it('should NOT auto-switch non-major/naturalMinor scale types on quality change', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    act(() => result.current.actions.setScaleType('lydian'));
+    act(() => result.current.actions.setChordQuality('minor'));
+    expect(result.current.state.selectedScale).toBe('lydian');
+
+    act(() => result.current.actions.setChordQuality('major'));
+    expect(result.current.state.selectedScale).toBe('lydian');
+  });
+
+  it('should auto-switch even when scale overlay is OFF', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    // showScale is false by default
+    expect(result.current.state.showScale).toBe(false);
+    expect(result.current.state.selectedScale).toBe('major');
+
+    act(() => result.current.actions.setChordQuality('minor'));
+    expect(result.current.state.selectedScale).toBe('naturalMinor');
+  });
+
+  it('should remember selected scale type after toggle OFF and ON', () => {
+    const { result } = renderHook(() => useCAGEDState());
+
+    act(() => result.current.actions.setScaleType('dorian'));
+    act(() => result.current.actions.toggleShowScale()); // ON
+    act(() => result.current.actions.toggleShowScale()); // OFF
+    act(() => result.current.actions.toggleShowScale()); // ON again
+
+    expect(result.current.state.selectedScale).toBe('dorian');
+    expect(result.current.state.showScale).toBe(true);
+  });
+});

--- a/src/systems/caged/hooks/useCAGEDLogic.ts
+++ b/src/systems/caged/hooks/useCAGEDLogic.ts
@@ -1,11 +1,15 @@
 import { useMemo } from 'react';
 import type { ChordType, ChordQuality } from '@/shared/types/core';
+import type { ScaleType } from '../types';
 import { CHROMATIC_VALUES, CAGED_SHAPES_BY_QUALITY } from '../constants';
+import { SCALE_DEFINITIONS } from '../constants/scales';
 import {
   getNoteNameAtFret,
   shouldShowNoteName,
   isPentatonicNote,
   getPentatonicPositions,
+  isScaleNote,
+  getScalePositions,
 } from '@/shared/utils/musicTheory';
 import { getPentatonicIntervals } from '@/shared/utils/chordUtils';
 
@@ -55,7 +59,8 @@ import { getPentatonicIntervals } from '@/shared/utils/chordUtils';
 export function useCAGEDLogic(
   selectedChord: ChordType,
   chordQuality: ChordQuality,
-  cagedSequence: string[]
+  cagedSequence: string[],
+  selectedScale: ScaleType = 'major'
 ) {
   // Get the appropriate shape data based on chord quality (major vs minor patterns)
   const shapeData = useMemo(() => CAGED_SHAPES_BY_QUALITY[chordQuality], [chordQuality]);
@@ -161,6 +166,23 @@ export function useCAGEDLogic(
     };
   }, [selectedChord, chordQuality]);
 
+  // Scale note detection using selected scale type
+  const isScaleNoteAtPosition = useMemo(() => {
+    const rootNote = CHROMATIC_VALUES[selectedChord];
+    const intervals = SCALE_DEFINITIONS[selectedScale].intervals;
+
+    return (stringIndex: number, fretNumber: number) => {
+      return isScaleNote(stringIndex, fretNumber, rootNote, intervals);
+    };
+  }, [selectedChord, selectedScale]);
+
+  // All scale positions across the fretboard
+  const allScalePositions = useMemo(() => {
+    const rootNote = CHROMATIC_VALUES[selectedChord];
+    const intervals = SCALE_DEFINITIONS[selectedScale].intervals;
+    return getScalePositions(rootNote, intervals);
+  }, [selectedChord, selectedScale]);
+
   // Use shared pentatonic positions utility
   const allPentatonicPositions = useMemo(() => {
     const rootNote = CHROMATIC_VALUES[selectedChord];
@@ -175,6 +197,8 @@ export function useCAGEDLogic(
     createGradientStyle,
     isPentatonicNote: isPentatonicNoteAtPosition,
     getPentatonicPositions: allPentatonicPositions,
+    isScaleNote: isScaleNoteAtPosition,
+    getScalePositions: allScalePositions,
     getNoteNameAtFret,
     shouldShowNoteName,
   };

--- a/src/systems/caged/hooks/useCAGEDState.ts
+++ b/src/systems/caged/hooks/useCAGEDState.ts
@@ -1,5 +1,5 @@
 import { useReducer } from 'react';
-import type { ChordType, ChordQuality } from '../types';
+import type { ChordType, ChordQuality, ScaleType } from '../types';
 
 interface CAGEDState {
   selectedChord: ChordType;
@@ -8,6 +8,8 @@ interface CAGEDState {
   showAllShapes: boolean;
   showPentatonic: boolean;
   showAllNotes: boolean;
+  showScale: boolean;
+  selectedScale: ScaleType;
 }
 
 type CAGEDAction =
@@ -18,7 +20,9 @@ type CAGEDAction =
   | { type: 'SET_POSITION'; payload: number }
   | { type: 'TOGGLE_SHOW_ALL_SHAPES' }
   | { type: 'TOGGLE_SHOW_PENTATONIC' }
-  | { type: 'TOGGLE_SHOW_ALL_NOTES' };
+  | { type: 'TOGGLE_SHOW_ALL_NOTES' }
+  | { type: 'TOGGLE_SHOW_SCALE' }
+  | { type: 'SET_SCALE_TYPE'; payload: ScaleType };
 
 function cagedReducer(state: CAGEDState, action: CAGEDAction): CAGEDState {
   switch (action.type) {
@@ -28,12 +32,20 @@ function cagedReducer(state: CAGEDState, action: CAGEDAction): CAGEDState {
         selectedChord: action.payload,
         currentPosition: 0, // Reset to first position when changing chord
       };
-    case 'SET_CHORD_QUALITY':
+    case 'SET_CHORD_QUALITY': {
+      let selectedScale = state.selectedScale;
+      // Auto-switch Major↔Natural Minor when chord quality changes
+      if (action.payload === 'minor' && state.selectedScale === 'major') {
+        selectedScale = 'naturalMinor';
+      } else if (action.payload === 'major' && state.selectedScale === 'naturalMinor') {
+        selectedScale = 'major';
+      }
       return {
         ...state,
         chordQuality: action.payload,
-        // Maintain current position when switching between major/minor
+        selectedScale,
       };
+    }
     case 'NEXT_POSITION':
       return {
         ...state,
@@ -66,6 +78,16 @@ function cagedReducer(state: CAGEDState, action: CAGEDAction): CAGEDState {
         ...state,
         showAllNotes: !state.showAllNotes,
       };
+    case 'TOGGLE_SHOW_SCALE':
+      return {
+        ...state,
+        showScale: !state.showScale,
+      };
+    case 'SET_SCALE_TYPE':
+      return {
+        ...state,
+        selectedScale: action.payload,
+      };
     default:
       return state;
   }
@@ -78,6 +100,8 @@ const initialState: CAGEDState = {
   showAllShapes: false,
   showPentatonic: false,
   showAllNotes: false,
+  showScale: false,
+  selectedScale: 'major',
 };
 
 /**
@@ -125,6 +149,8 @@ export function useCAGEDState(): {
     toggleShowAllShapes: () => void;
     toggleShowPentatonic: () => void;
     toggleShowAllNotes: () => void;
+    toggleShowScale: () => void;
+    setScaleType: (scaleType: ScaleType) => void;
   };
 } {
   const [state, dispatch] = useReducer(cagedReducer, initialState);
@@ -141,6 +167,9 @@ export function useCAGEDState(): {
     toggleShowAllShapes: () => dispatch({ type: 'TOGGLE_SHOW_ALL_SHAPES' }),
     toggleShowPentatonic: () => dispatch({ type: 'TOGGLE_SHOW_PENTATONIC' }),
     toggleShowAllNotes: () => dispatch({ type: 'TOGGLE_SHOW_ALL_NOTES' }),
+    toggleShowScale: () => dispatch({ type: 'TOGGLE_SHOW_SCALE' }),
+    setScaleType: (scaleType: ScaleType) =>
+      dispatch({ type: 'SET_SCALE_TYPE', payload: scaleType }),
   };
 
   return {

--- a/src/systems/caged/hooks/useKeyboardNavigation.ts
+++ b/src/systems/caged/hooks/useKeyboardNavigation.ts
@@ -9,6 +9,7 @@ interface UseKeyboardNavigationProps {
   onToggleShowAllShapes: () => void;
   onToggleShowPentatonic: () => void;
   onToggleShowAllNotes: () => void;
+  onToggleShowScale: () => void;
 }
 
 /**
@@ -64,6 +65,7 @@ export function useKeyboardNavigation({
   onToggleShowAllShapes,
   onToggleShowPentatonic,
   onToggleShowAllNotes,
+  onToggleShowScale,
 }: UseKeyboardNavigationProps) {
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -115,6 +117,12 @@ export function useKeyboardNavigation({
           event.preventDefault();
           onToggleShowAllNotes();
           break;
+        case 'm':
+        case 'M':
+          if (event.ctrlKey || event.metaKey) return;
+          event.preventDefault();
+          onToggleShowScale();
+          break;
       }
     };
 
@@ -129,5 +137,6 @@ export function useKeyboardNavigation({
     onToggleShowAllShapes,
     onToggleShowPentatonic,
     onToggleShowAllNotes,
+    onToggleShowScale,
   ]);
 }

--- a/src/systems/caged/types/index.ts
+++ b/src/systems/caged/types/index.ts
@@ -6,9 +6,10 @@
  */
 
 import type { ChordType, ChordQuality, MusicShape, ShapesByQuality } from '@/shared/types/core';
+import type { ScaleType } from '../constants/scales';
 
 // Re-export shared types for CAGED system use
-export type { ChordType, ChordQuality };
+export type { ChordType, ChordQuality, ScaleType };
 
 /**
  * Individual CAGED chord shape definition
@@ -61,6 +62,10 @@ export interface CAGEDState {
   showPentatonic: boolean;
   /** Whether to show all note names */
   showAllNotes: boolean;
+  /** Whether to show scale overlay */
+  showScale: boolean;
+  /** Currently selected scale type */
+  selectedScale: ScaleType;
 }
 
 /**
@@ -88,9 +93,13 @@ export interface CAGEDViewModeProps {
   showAllShapes: boolean;
   showPentatonic: boolean;
   showAllNotes: boolean;
+  showScale: boolean;
+  selectedScale: ScaleType;
   onToggleShowAllShapes: () => void;
   onToggleShowPentatonic: () => void;
   onToggleShowAllNotes: () => void;
+  onToggleShowScale: () => void;
+  onSetScaleType: (scaleType: ScaleType) => void;
 }
 
 /**


### PR DESCRIPTION
Adds a purple scale overlay with 9 scale types (major, 3 minor variants,
5 modes) selectable via inline grouped dropdown. In single-shape mode,
scale notes are scoped to the current shape's fret range +/-2 frets;
Show All Shapes mode displays them across the full fretboard.

Major <-> Natural Minor auto-switches when chord quality toggles; other
scale types stay put. Bound to the M keyboard shortcut.

Overlapping dots stack additional rings (key note, pentatonic, scale)
via box-shadow rather than splitting colors, mirroring the existing
pentatonic ring approach.
